### PR TITLE
Improve performance

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,19 +1,54 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "$ref": "#/definitions/build",
-  "title": "Build Schema",
   "definitions": {
-    "build": {
-      "type": "object",
+    "Host": {
+      "type": "string",
+      "enum": [
+        "AppVeyor",
+        "AzurePipelines",
+        "Bamboo",
+        "Bitbucket",
+        "Bitrise",
+        "GitHubActions",
+        "GitLab",
+        "Jenkins",
+        "Rider",
+        "SpaceAutomation",
+        "TeamCity",
+        "Terminal",
+        "TravisCI",
+        "VisualStudio",
+        "VSCode"
+      ]
+    },
+    "ExecutableTarget": {
+      "type": "string",
+      "enum": [
+        "BuildRustAll",
+        "BuildRustLocal",
+        "BuildRustSingle",
+        "Clean",
+        "Compile",
+        "Pack",
+        "PublishGitHub",
+        "PublishNuGet",
+        "Restore",
+        "RustTest",
+        "Test"
+      ]
+    },
+    "Verbosity": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Verbose",
+        "Normal",
+        "Minimal",
+        "Quiet"
+      ]
+    },
+    "NukeBuild": {
       "properties": {
-        "Config": {
-          "type": "string",
-          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
-          "enum": [
-            "Debug",
-            "Release"
-          ]
-        },
         "Continue": {
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
@@ -23,37 +58,12 @@
           "description": "Shows the help text for this build assembly"
         },
         "Host": {
-          "type": "string",
           "description": "Host for execution. Default is 'automatic'",
-          "enum": [
-            "AppVeyor",
-            "AzurePipelines",
-            "Bamboo",
-            "Bitbucket",
-            "Bitrise",
-            "GitHubActions",
-            "GitLab",
-            "Jenkins",
-            "Rider",
-            "SpaceAutomation",
-            "TeamCity",
-            "Terminal",
-            "TravisCI",
-            "VisualStudio",
-            "VSCode"
-          ]
-        },
-        "LibName": {
-          "type": "string",
-          "description": "Library filename produced by cargo"
+          "$ref": "#/definitions/Host"
         },
         "NoLogo": {
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
-        },
-        "NuGetApiKey": {
-          "type": "string",
-          "description": "NuGet API key"
         },
         "Partition": {
           "type": "string",
@@ -74,6 +84,46 @@
           "type": "string",
           "description": "Root directory during build execution"
         },
+        "Skip": {
+          "type": "array",
+          "description": "List of targets to be skipped. Empty list skips all dependencies",
+          "items": {
+            "$ref": "#/definitions/ExecutableTarget"
+          }
+        },
+        "Target": {
+          "type": "array",
+          "description": "List of targets to be invoked. Default is '{default_target}'",
+          "items": {
+            "$ref": "#/definitions/ExecutableTarget"
+          }
+        },
+        "Verbosity": {
+          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "$ref": "#/definitions/Verbosity"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "properties": {
+        "Config": {
+          "type": "string",
+          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
+        "LibName": {
+          "type": "string",
+          "description": "Library filename produced by cargo"
+        },
+        "NuGetApiKey": {
+          "type": "string",
+          "description": "NuGet API key"
+        },
         "RuntimeId": {
           "type": "string",
           "description": "Runtime identifier for the current platform"
@@ -82,63 +132,18 @@
           "type": "string",
           "description": "Rust target triple to build (single platform CI mode)"
         },
-        "Skip": {
-          "type": "array",
-          "description": "List of targets to be skipped. Empty list skips all dependencies",
-          "items": {
-            "type": "string",
-            "enum": [
-              "BuildRustAll",
-              "BuildRustSingle",
-              "Clean",
-              "Compile",
-              "Pack",
-              "PublishGitHub",
-              "PublishNuGet",
-              "Restore",
-              "RustTest",
-              "Test"
-            ]
-          }
-        },
         "Solution": {
           "type": "string",
           "description": "Path to a solution file that is automatically loaded"
-        },
-        "Target": {
-          "type": "array",
-          "description": "List of targets to be invoked. Default is '{default_target}'",
-          "items": {
-            "type": "string",
-            "enum": [
-              "BuildRustAll",
-              "BuildRustSingle",
-              "Clean",
-              "Compile",
-              "Pack",
-              "PublishGitHub",
-              "PublishNuGet",
-              "Restore",
-              "RustTest",
-              "Test"
-            ]
-          }
-        },
-        "Verbosity": {
-          "type": "string",
-          "description": "Logging verbosity during build execution. Default is 'Normal'",
-          "enum": [
-            "Minimal",
-            "Normal",
-            "Quiet",
-            "Verbose"
-          ]
         },
         "Version": {
           "type": "string",
           "description": "Version for NuGet package"
         }
       }
+    },
+    {
+      "$ref": "#/definitions/NukeBuild"
     }
-  }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![Alt text](https://raw.githubusercontent.com/gregyjames/HyperTrie/main/mini_trie.png "package icon")
 # HyperTrie
-HyperTrie is a hyper optimized C# prefix tree written in Rust. It is currently the fastest C# Trie implementation, about 601% faster than TrieNet.Core 😮‍💨
+HyperTrie is a hyper optimized C# prefix tree written in Rust. It is currently the fastest C# Trie implementation, about 1,300% faster (92.71% less time) than TrieNet.Core 😮‍💨
 
 ## Why make this?
 Well, I wanted to try optimizing some of the hot paths in one of my libraries [Octane Downloader](https://github.com/gregyjames/OctaneDownloader) by rewritting them in Rust, but in order to do that, I needed a simpler project to experiment with multi-target builds and including native rust code in a Nuget package. Then I proceeded to optimize the hell out of it for no reason just to see how far I could go. I'm sure there potentially more optimizations to make, like using u8 instead of char for space complexity, so if you see anything feel free to open a PR.
@@ -37,18 +37,18 @@ trieNative.BulkInsert(allWords);
 ## Benchmark
 ```
 
-BenchmarkDotNet v0.14.0, macOS 26.1 (25B78) [Darwin 25.1.0]
+BenchmarkDotNet v0.15.8, macOS Tahoe 26.1 (25B78) [Darwin 25.1.0]
 Apple M1, 1 CPU, 8 logical and 8 physical cores
-.NET SDK 8.0.100
-  [Host] : .NET 8.0.0 (8.0.23.53103), Arm64 RyuJIT AdvSIMD
+.NET SDK 10.0.201
+  [Host] : .NET 8.0.0 (8.0.0, 8.0.23.53103), Arm64 RyuJIT armv8.0-a
 
 Toolchain=InProcessEmitToolchain  
 
 ```
-| Method               | Mean      | Error    | StdDev   | Rank | Gen0       | Gen1      | Gen2      | Allocated |
-|--------------------- |----------:|---------:|---------:|-----:|-----------:|----------:|----------:|----------:|
-| &#39;TrieNet (C#)&#39;       | 226.32 ms | 3.409 ms | 3.022 ms |    2 | 19500.0000 | 8000.0000 | 3000.0000 | 104.56 MB |
-| &#39;HyperTrie (Native)&#39; |  38.52 ms | 0.744 ms | 0.764 ms |    1 |   538.4615 |  538.4615 |  153.8462 |   2.06 MB |
+| Method               | Mean      | Error    | StdDev   | Median    | Rank | Gen0       | Gen1      | Gen2      | Allocated    |
+|--------------------- |----------:|---------:|---------:|----------:|-----:|-----------:|----------:|----------:|-------------:|
+| &#39;TrieNet (C#)&#39;       | 223.19 ms | 3.119 ms | 2.917 ms | 222.76 ms |    2 | 19500.0000 | 8000.0000 | 3000.0000 | 107064.97 KB |
+| &#39;HyperTrie (Native)&#39; |  16.27 ms | 0.325 ms | 0.872 ms |  15.93 ms |    1 |          - |         - |         - |     85.25 KB |
 
 
 ## Limitations

--- a/src/HyperTrieCore/TrieNative.cs
+++ b/src/HyperTrieCore/TrieNative.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -36,7 +37,7 @@ public class TrieNative(int size, int numHashes) : IDisposable
         out UIntPtr out_len);
     
     [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
-    private static extern void trie_bulk_insert(IntPtr trie, IntPtr[] words, UIntPtr len);
+    private static extern void trie_bulk_insert(IntPtr trie, IntPtr words, UIntPtr len);
     public void Insert(string word)
     {
         using var wordPtr = new Utf8String(word);
@@ -84,66 +85,51 @@ public class TrieNative(int size, int numHashes) : IDisposable
     {
         // Materialize words once
         int count = words.Count;
+        if (count == 0) return;
         
-        // Calculate total buffer size for all UTF8 strings + null terminators
-        var totalSize = 0;
-        var offsets = new List<int>(count);
+        int totalByteCapacity = 0;
+        foreach (var word in words) totalByteCapacity += (word.Length * 3) + 1; // Worst case UTF8
 
-        foreach (var word in words)
-        {
-            offsets.Add(totalSize);
-            var byteCount = Encoding.UTF8.GetByteCount(word);
-            totalSize += byteCount + 1; // +1 for null terminator
-        }
-
-        // Allocate one big unmanaged buffer
-        IntPtr bigBuffer = Marshal.AllocHGlobal(totalSize);
-
-        // Allocate managed pointer array
-        IntPtr[] ptrArray = new IntPtr[count];
-
+        IntPtr bigBuffer = Marshal.AllocHGlobal((IntPtr)totalByteCapacity);
+        IntPtr[] ptrArray = ArrayPool<IntPtr>.Shared.Rent(count);
+        
+        
         try
         {
-            byte* basePtr = (byte*)bigBuffer.ToPointer();
-
-            /*
-            for (int i = 0; i < count; i++)
-            {
-                var sourceSpan = wordList[i].AsSpan();
-                var offset = offsets[i];
-                var destSpan = new Span<byte>(basePtr + offset, totalSize - offset);
-
-                int bytesEncoded = Encoding.UTF8.GetBytes(sourceSpan, destSpan);
-                destSpan[bytesEncoded] = 0; // null terminator
-                ptrArray[i] = (IntPtr)(basePtr + offset);
-            }*/
-
+            byte* currentDest = (byte*)bigBuffer.ToPointer();
+            
             #if NET5_0_OR_GREATER
-                var collection = CollectionsMarshal.AsSpan(words);
-                ref var searchSpace = ref MemoryMarshal.GetReference(collection);
+                var span = CollectionsMarshal.AsSpan(words);
             #else
-                var collection = words.ToArray();
-                ref var searchSpace = ref MemoryMarshal.GetReference(collection.AsSpan());
+                var span = words.ToArray().AsSpan();
             #endif
-            
+
             for (int i = 0; i < count; i++)
             {
-                var item = Unsafe.Add(ref searchSpace, i).AsSpan();
-                var offset = offsets[i];
-                var destSpan = new Span<byte>(basePtr + offset, totalSize - offset);
+                string s = span[i];
+                if (s == null) continue;
+                
+                ptrArray[i] = (IntPtr)currentDest;
 
-                int bytesEncoded = Encoding.UTF8.GetBytes(item, destSpan);
-                destSpan[bytesEncoded] = 0; // null terminator
-                ptrArray[i] = (IntPtr)(basePtr + offset);
+                fixed (char* pStr = s)
+                {
+                    int bytesWritten = Encoding.UTF8.GetBytes(pStr, s.Length, currentDest, totalByteCapacity);
+                    
+                    currentDest += bytesWritten;
+                    *currentDest = 0; // Null terminator
+                    currentDest++;
+                }
             }
-            
-            // Call Rust bulk insert once
-            trie_bulk_insert(_handle, ptrArray, (UIntPtr)ptrArray.Length);
+
+            fixed (IntPtr* pPtrs = ptrArray)
+            {
+                trie_bulk_insert(_handle, (IntPtr)pPtrs, (UIntPtr)count);
+            }
         }
         finally
         {
-            // Free single big buffer
             Marshal.FreeHGlobal(bigBuffer);
+            ArrayPool<IntPtr>.Shared.Return(ptrArray);
         }
     }
     

--- a/src/HyperTrieCore/TrieNative.cs
+++ b/src/HyperTrieCore/TrieNative.cs
@@ -1,5 +1,4 @@
 using System.Buffers;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -44,27 +43,38 @@ public class TrieNative(int size, int numHashes) : IDisposable
         trie_insert(_handle, wordPtr.Pointer);
     }
 
-    public List<string> GetWordsWithPrefix(string prefix)
+    public unsafe List<string> GetWordsWithPrefix(string prefix)
     {
         var result = new List<string>();
         
         using var prefixPtr = new Utf8String(prefix);
-        var wordsPtr = trie_words_with_prefix(_handle, prefixPtr.Pointer, out var len);
-        var length = len.ToUInt64();
+        var wordsPtr = (IntPtr*)trie_words_with_prefix(_handle, prefixPtr.Pointer, out var len);
+        var count = len.ToUInt32();
 
-        if (wordsPtr != IntPtr.Zero && length > 0)
+        if (wordsPtr == null || count == 0)
         {
-            IntPtr[] stringPtrs = new IntPtr[length];
-            Marshal.Copy(wordsPtr, stringPtrs, 0, (int)length);
+            return new List<string>(0);
+        }
 
-            for (ulong i = 0; i < length; i++)
+        try
+        {
+            for (uint i = 0; i < count; i++)
             {
-                string? word = Marshal.PtrToStringUTF8(stringPtrs[i]);
-                if (word != null) result.Add(word);
-            }
+                var currentWordPtr = wordsPtr[i];
 
-            // Free the words array & strings
-            trie_free_words(wordsPtr, len);
+                if (currentWordPtr != IntPtr.Zero)
+                {
+                    var word = Marshal.PtrToStringUTF8(currentWordPtr);
+                    if (word != null)
+                    {
+                        result.Add(word);
+                    }
+                }
+            }
+        }
+        finally
+        {
+            trie_free_words((IntPtr)wordsPtr, len);
         }
         
         return result;

--- a/src/HyperTrieCore/Utf8String.cs
+++ b/src/HyperTrieCore/Utf8String.cs
@@ -6,25 +6,32 @@ namespace HyperTrieCore;
 /// <summary>
 /// Helper to marshal C# string to UTF8 IntPtr with disposal.
 /// </summary>
-internal class Utf8String : IDisposable
+internal unsafe ref struct Utf8String : IDisposable
 {
     public IntPtr Pointer { get; private set; }
 
     public Utf8String(string str)
     {
-        if (str == null) throw new ArgumentNullException(nameof(str));
-
-        // Get byte array directly, with null terminator
-        byte[] utf8Bytes = Encoding.UTF8.GetBytes(str);
-        int lengthWithNullTerminator = utf8Bytes.Length + 1;  // +1 for the null terminator
-
-        // Allocate memory and copy bytes to unmanaged memory
-        Pointer = Marshal.AllocHGlobal(lengthWithNullTerminator);
-        Marshal.Copy(utf8Bytes, 0, Pointer, utf8Bytes.Length);
-        Marshal.WriteByte(Pointer + utf8Bytes.Length, 0); 
-    }
+        if (string.IsNullOrEmpty(str))
+        {
+            Pointer = IntPtr.Zero;
+            return;
+        };
         
-    private bool _disposed;
+        fixed (char* pStr = str)
+        {
+            int byteCount = Encoding.UTF8.GetByteCount(pStr, str.Length);
+            
+            Pointer = Marshal.AllocHGlobal(byteCount + 1);
+            
+            byte* pDest = (byte*)Pointer;
+            Encoding.UTF8.GetBytes(pStr, str.Length, pDest, byteCount);
+
+            pDest[byteCount] = 0;
+        }
+    }
+
+    private bool _disposed = false;
 
     public void Dispose()
     {
@@ -37,11 +44,5 @@ internal class Utf8String : IDisposable
         }
 
         _disposed = true;
-        GC.SuppressFinalize(this);
-    }
-        
-    ~Utf8String()
-    {
-        Dispose();
     }
 }

--- a/src/hypertrie/src/bloom_filter.rs
+++ b/src/hypertrie/src/bloom_filter.rs
@@ -3,7 +3,6 @@ use gxhash::GxHasher;
 use std::hash::Hasher;
 
 const SEED: i64 = 1846279233212321312;
-const SEED2: i64 = 918273645546372819;
 
 pub struct BloomFilter {
     bit_array: BitVec,

--- a/src/hypertrie/src/bloom_filter.rs
+++ b/src/hypertrie/src/bloom_filter.rs
@@ -24,7 +24,8 @@ impl BloomFilter {
         let base_hash = self.get_base_hash(item);
         for i in 0..self.num_hashes {
             let final_hash = self.derive_hash(base_hash, i);
-            self.bit_array.set(final_hash % self.size, true);
+            let index = final_hash & (self.size - 1);
+            self.bit_array.set(index, true);
         }
     }
 
@@ -32,8 +33,9 @@ impl BloomFilter {
         let base_hash = self.get_base_hash(item);
         for i in 0..self.num_hashes {
             let final_hash = self.derive_hash(base_hash, i);
+            let index = final_hash & (self.size - 1);
 
-            if !self.bit_array.get(final_hash % self.size).unwrap_or(false) {
+            if !self.bit_array.get(index).unwrap_or(false) {
                 return false;
             }
         }

--- a/src/hypertrie/src/bloom_filter.rs
+++ b/src/hypertrie/src/bloom_filter.rs
@@ -3,6 +3,7 @@ use gxhash::GxHasher;
 use std::hash::Hasher;
 
 const SEED: i64 = 1846279233212321312;
+const SEED2: i64 = 918273645546372819;
 
 pub struct BloomFilter {
     bit_array: BitVec,
@@ -12,45 +13,48 @@ pub struct BloomFilter {
 
 impl BloomFilter {
     pub fn new(size: usize, num_hashes: usize) -> Self {
-        let bit_array = BitVec::from_elem(size, false);
         BloomFilter {
-            bit_array,
+            bit_array: BitVec::from_elem(size, false),
             size,
             num_hashes,
         }
     }
 
     pub fn insert(&mut self, item: &str) {
-        let hashes = self.hash_item(item);
-        for hash in hashes {
-            self.bit_array.set(hash % self.size, true);
+        let base_hash = self.get_base_hash(item);
+        for i in 0..self.num_hashes {
+            let final_hash = self.derive_hash(base_hash, i);
+            self.bit_array.set(final_hash % self.size, true);
         }
     }
 
     pub fn contains(&self, item: &str) -> bool {
-        let hashes = self.hash_item(item);
-        for hash in hashes {
-            if !self.bit_array[hash % self.size] {
-                return false; // Definitely not in the set
+        let base_hash = self.get_base_hash(item);
+        for i in 0..self.num_hashes {
+            let final_hash = self.derive_hash(base_hash, i);
+
+            if !self.bit_array.get(final_hash % self.size).unwrap_or(false) {
+                return false;
             }
         }
         true // Maybe in the set (false positives possible)
     }
 
-    fn hash_item(&self, item: &str) -> Vec<usize> {
-        let mut hashes = Vec::new();
+    #[inline(always)]
+    fn get_base_hash(&self, item: &str) -> u64 {
+        let mut hasher = GxHasher::with_seed(SEED);
+        hasher.write(item.as_bytes());
+        hasher.finish()
+    }
 
-        for i in 0..self.num_hashes {
-            let mut hasher = GxHasher::with_seed(SEED);
-            let input = item.as_bytes();
-
-            hasher.write(input);
-            hasher.write(&[i as u8]); // Adding a unique salt to make the hashes different
-
-            let hash = hasher.finish() as usize;
-            hashes.push(hash);
-        }
-        hashes
+    /// Derive subsequent hashes from the base hash + index
+    /// This is significantly faster than hashing the string again
+    #[inline(always)]
+    fn derive_hash(&self, base_hash: u64, index: usize) -> usize {
+        let mut hasher = GxHasher::with_seed(SEED);
+        hasher.write_u64(base_hash);
+        hasher.write_usize(index);
+        hasher.finish() as usize
     }
 }
 
@@ -177,12 +181,22 @@ mod tests {
     }
 
     // --- hash_item determinism ---
+    /// Helper to collect hashes for testing since we removed hash_item from the API
+    fn get_hashes(bf: &BloomFilter, item: &str) -> Vec<usize> {
+        let mut hashes = Vec::new();
+        let base_hash = bf.get_base_hash(item);
+        for i in 0..bf.num_hashes {
+            let final_hash = bf.derive_hash(base_hash, i);
+            hashes.push(final_hash % bf.size);
+        }
+        hashes
+    }
 
     #[test]
     fn test_hashing_is_deterministic() {
         let bf = make_filter(1024, 3);
-        let h1 = bf.hash_item("stable");
-        let h2 = bf.hash_item("stable");
+        let h1 = get_hashes(&bf, "stable");
+        let h2 = get_hashes(&bf, "stable");
         assert_eq!(h1, h2);
     }
 
@@ -191,7 +205,7 @@ mod tests {
         // Each of the num_hashes slots should (almost certainly) differ for a
         // non-degenerate input, confirming the per-index salt is applied.
         let bf = make_filter(1024, 4);
-        let hashes = bf.hash_item("salt_test");
+        let hashes = get_hashes(&bf, "salt_test");
         // Not all hashes should be equal — if they were, the filter would
         // only ever set/check one bit position regardless of num_hashes.
         let unique: std::collections::HashSet<usize> = hashes.iter().copied().collect();
@@ -201,7 +215,8 @@ mod tests {
     #[test]
     fn test_hash_count_matches_num_hashes() {
         let bf = make_filter(1024, 5);
-        assert_eq!(bf.hash_item("count").len(), 5);
+        let hashes = get_hashes(&bf, "count");
+        assert_eq!(hashes.len(), 5, "Should generate exactly num_hashes values");
     }
 
     // --- false positive rate sanity check ---

--- a/src/hypertrie/src/lib.rs
+++ b/src/hypertrie/src/lib.rs
@@ -159,9 +159,10 @@ pub unsafe extern "C" fn trie_bulk_insert(
         #[allow(clippy::collapsible_if)]
         for &word_ptr in slice {
             if !word_ptr.is_null() {
-                if let Ok(word) = CStr::from_ptr(word_ptr).to_str() {
-                    trie.insert(word);
-                }
+                let word = unsafe { 
+                    std::str::from_utf8_unchecked(CStr::from_ptr(word_ptr).to_bytes()) 
+                };
+                trie.insert(word);
             }
         }
     }

--- a/src/hypertrie/src/lib.rs
+++ b/src/hypertrie/src/lib.rs
@@ -156,11 +156,9 @@ pub unsafe extern "C" fn trie_bulk_insert(
     unsafe {
         let slice = slice::from_raw_parts(words, len);
         let trie = &mut *trie;
-        #[allow(clippy::collapsible_if)]
         for &word_ptr in slice {
             if !word_ptr.is_null() {
-                let word =
-                    unsafe { std::str::from_utf8_unchecked(CStr::from_ptr(word_ptr).to_bytes()) };
+                let word = std::str::from_utf8_unchecked(CStr::from_ptr(word_ptr).to_bytes());
                 trie.insert(word);
             }
         }

--- a/src/hypertrie/src/lib.rs
+++ b/src/hypertrie/src/lib.rs
@@ -159,9 +159,8 @@ pub unsafe extern "C" fn trie_bulk_insert(
         #[allow(clippy::collapsible_if)]
         for &word_ptr in slice {
             if !word_ptr.is_null() {
-                let word = unsafe { 
-                    std::str::from_utf8_unchecked(CStr::from_ptr(word_ptr).to_bytes()) 
-                };
+                let word =
+                    unsafe { std::str::from_utf8_unchecked(CStr::from_ptr(word_ptr).to_bytes()) };
                 trie.insert(word);
             }
         }

--- a/src/hypertrie/src/trie.rs
+++ b/src/hypertrie/src/trie.rs
@@ -27,7 +27,9 @@ pub struct Trie {
 
 impl Trie {
     pub fn new(size: usize, num_hashes: usize) -> Self {
-        let optimized_size = size.checked_next_power_of_two().expect("Next power of 2 usize overflow");
+        let optimized_size = size
+            .checked_next_power_of_two()
+            .expect("Next power of 2 usize overflow");
 
         let mut nodes = Vec::with_capacity(1024);
         nodes.push(Node::new(0));
@@ -141,7 +143,12 @@ impl Trie {
         results
     }
 
-    fn collect_words_from_node(&self, node_idx: usize, buffer: &mut Vec<u8>, results: &mut Vec<String>) {
+    fn collect_words_from_node(
+        &self,
+        node_idx: usize,
+        buffer: &mut Vec<u8>,
+        results: &mut Vec<String>,
+    ) {
         let node = &self.nodes[node_idx];
 
         // If this node marks the end of a word, save the current buffer

--- a/src/hypertrie/src/trie.rs
+++ b/src/hypertrie/src/trie.rs
@@ -3,82 +3,98 @@ use crate::bloom_filter::BloomFilter;
 const ALPHABET_SIZE: usize = 26;
 
 pub struct Node {
-    letter: u8,
-    children: [Option<Box<Node>>; ALPHABET_SIZE],
-    end_of_word: bool,
+    pub letter: u8,
+    pub children_mask: u32,
+    pub children_indices: [u32; 26],
+    pub end_of_word: bool,
 }
 
 impl Node {
     fn new(letter: u8) -> Self {
-        const NODE_NODE: Option<Box<Node>> = None;
-
         Node {
             letter,
-            children: [NODE_NODE; ALPHABET_SIZE],
+            children_mask: 0,
+            children_indices: [0; ALPHABET_SIZE],
             end_of_word: false,
         }
-    }
-
-    #[inline(always)]
-    fn char_to_index(c: u8) -> usize {
-        (c.to_ascii_lowercase() - b'a') as usize
     }
 }
 
 pub struct Trie {
-    root: Box<Node>,
+    nodes: Vec<Node>,
     bloom_filter: BloomFilter,
 }
 
 impl Trie {
     pub fn new(size: usize, num_hashes: usize) -> Self {
+        let mut nodes = Vec::with_capacity(1024);
+        nodes.push(Node::new(0));
+
         Trie {
-            root: Box::new(Node::new(0)),
+            nodes,
             bloom_filter: BloomFilter::new(size, num_hashes),
         }
     }
 
     pub fn insert(&mut self, word: &str) {
+        let mut current_idx = 0;
         let bytes = word.as_bytes();
-        let mut current = &mut self.root;
 
-        for &c in bytes {
-            let idx = Node::char_to_index(c);
-            if current.children[idx].is_none() {
-                current.children[idx] = Some(Box::new(Node::new(c)));
+        for &b in bytes {
+            let char_val = b.to_ascii_lowercase();
+            let bit_idx = (char_val - b'a') as usize;
+
+            // Check if child exists using bitmask
+            if (self.nodes[current_idx].children_mask & (1 << bit_idx)) == 0 {
+                let new_node_idx = self.nodes.len() as u32;
+                self.nodes.push(Node::new(char_val));
+
+                // Update parent
+                let node = &mut self.nodes[current_idx];
+                node.children_mask |= 1 << bit_idx;
+                node.children_indices[bit_idx] = new_node_idx;
+
+                current_idx = new_node_idx as usize;
+            } else {
+                current_idx = self.nodes[current_idx].children_indices[bit_idx] as usize;
             }
-            current = current.children[idx].as_mut().unwrap();
         }
 
-        current.end_of_word = true;
+        self.nodes[current_idx].end_of_word = true;
         self.bloom_filter.insert(word);
     }
 
     pub fn contains(&self, word: &str) -> bool {
+        // Bloom Filter is usually faster than a full Trie walk for non-members
         if !self.bloom_filter.contains(word) {
             return false;
         }
 
-        let mut current = &self.root;
-
+        let mut current_idx = 0;
         for &b in word.as_bytes() {
-            let idx = Node::char_to_index(b);
-            match &current.children[idx] {
-                Some(node) => current = node,
-                None => return false,
+            let char_val = b.to_ascii_lowercase();
+            let bit_idx = (char_val - b'a') as usize;
+
+            let node = &self.nodes[current_idx];
+            if (node.children_mask & (1 << bit_idx)) == 0 {
+                return false;
             }
+            current_idx = node.children_indices[bit_idx] as usize;
         }
 
-        current.end_of_word
+        self.nodes[current_idx].end_of_word
     }
 
     pub fn print(&self) {
-        self.debug_print(&self.root, 0);
+        // Start at index 0 (the root)
+        self.debug_print(0, 0);
     }
 
-    fn debug_print(&self, node: &Node, indent: usize) {
+    fn debug_print(&self, node_idx: usize, indent: usize) {
+        let node = &self.nodes[node_idx];
         let padding = "  ".repeat(indent);
-        if indent == 0 {
+
+        if node_idx == 0 {
             println!("Root");
         } else {
             println!(
@@ -86,40 +102,62 @@ impl Trie {
                 padding, node.letter as char, node.end_of_word
             );
         }
-        for child in node.children.iter().flatten() {
-            self.debug_print(child, indent + 1);
+
+        // Since we are using a bitmask and an index array, we iterate
+        // through the alphabet and check the mask.
+        for i in 0..26 {
+            if (node.children_mask & (1 << i)) != 0 {
+                let child_idx = node.children_indices[i] as usize;
+                self.debug_print(child_idx, indent + 1);
+            }
         }
     }
 
     pub fn words_with_prefix(&self, prefix: &str) -> Vec<String> {
-        let mut current = &self.root;
+        let mut current_idx = 0; // Start at root
         let bytes = prefix.as_bytes();
 
+        // 1. Navigate to the end of the prefix
         for &b in bytes {
-            let idx = Node::char_to_index(b);
-            match &current.children[idx] {
-                Some(node) => current = node,
-                None => return Vec::new(),
+            let char_val = b.to_ascii_lowercase();
+            let bit_idx = (char_val - b'a') as usize;
+
+            let node = &self.nodes[current_idx];
+            // Use the bitmask to check if the path exists
+            if (node.children_mask & (1 << bit_idx)) == 0 {
+                return Vec::new(); // Prefix not found
             }
+            current_idx = node.children_indices[bit_idx] as usize;
         }
 
+        // 2. Collect all words starting from this node
         let mut results = Vec::new();
+        // Pre-allocate the buffer with the prefix to avoid mid-search reallocations
         let mut buffer = prefix.to_ascii_lowercase().into_bytes();
-        self.collect_words_from_node(current, &mut buffer, &mut results);
+
+        self.collect_words_from_node(current_idx, &mut buffer, &mut results);
         results
     }
 
-    #[inline(always)]
-    fn collect_words_from_node(&self, node: &Node, buffer: &mut Vec<u8>, results: &mut Vec<String>) {
+    fn collect_words_from_node(&self, node_idx: usize, buffer: &mut Vec<u8>, results: &mut Vec<String>) {
+        let node = &self.nodes[node_idx];
+
+        // If this node marks the end of a word, save the current buffer
         if node.end_of_word {
+            // Optimization: Use String::from_utf8_unchecked if you're 100% sure of ASCII
             results.push(String::from_utf8_lossy(buffer).into_owned());
         }
 
-        for (i, child_opt) in node.children.iter().enumerate() {
-            if let Some(child) = child_opt {
+        // Iterate through all possible children (a-z)
+        for i in 0..26 {
+            // Only recurse if the bitmask says a child exists
+            if (node.children_mask & (1 << i)) != 0 {
+                let child_idx = node.children_indices[i] as usize;
+
+                // Push the character for this branch
                 buffer.push(b'a' + i as u8);
-                self.collect_words_from_node(child, buffer, results);
-                buffer.pop();
+                self.collect_words_from_node(child_idx, buffer, results);
+                buffer.pop(); // Backtrack for the next branch
             }
         }
     }

--- a/src/hypertrie/src/trie.rs
+++ b/src/hypertrie/src/trie.rs
@@ -3,23 +3,25 @@ use crate::bloom_filter::BloomFilter;
 const ALPHABET_SIZE: usize = 26;
 
 pub struct Node {
-    letter: char,
+    letter: u8,
     children: [Option<Box<Node>>; ALPHABET_SIZE],
     end_of_word: bool,
 }
 
 impl Node {
-    fn new(letter: char) -> Self {
+    fn new(letter: u8) -> Self {
+        const NODE_NODE: Option<Box<Node>> = None;
+
         Node {
             letter,
-            children: Default::default(),
+            children: [NODE_NODE; ALPHABET_SIZE],
             end_of_word: false,
         }
     }
 
     #[inline(always)]
-    fn char_to_index(c: char) -> usize {
-        (c as u8 - b'a') as usize
+    fn char_to_index(c: u8) -> usize {
+        (c.to_ascii_lowercase() - b'a') as usize
     }
 }
 
@@ -31,15 +33,16 @@ pub struct Trie {
 impl Trie {
     pub fn new(size: usize, num_hashes: usize) -> Self {
         Trie {
-            root: Box::new(Node::new('\0')),
+            root: Box::new(Node::new(0)),
             bloom_filter: BloomFilter::new(size, num_hashes),
         }
     }
 
     pub fn insert(&mut self, word: &str) {
+        let bytes = word.as_bytes();
         let mut current = &mut self.root;
 
-        for c in word.chars().map(|c| c.to_ascii_lowercase()) {
+        for &c in bytes {
             let idx = Node::char_to_index(c);
             if current.children[idx].is_none() {
                 current.children[idx] = Some(Box::new(Node::new(c)));
@@ -58,8 +61,8 @@ impl Trie {
 
         let mut current = &self.root;
 
-        for c in word.to_ascii_lowercase().chars() {
-            let idx = Node::char_to_index(c);
+        for &b in word.as_bytes() {
+            let idx = Node::char_to_index(b);
             match &current.children[idx] {
                 Some(node) => current = node,
                 None => return false,
@@ -75,10 +78,12 @@ impl Trie {
 
     fn debug_print(&self, node: &Node, indent: usize) {
         let padding = "  ".repeat(indent);
-        if node.letter != '\0' {
+        if indent == 0 {
+            println!("Root");
+        } else {
             println!(
                 "{}'{}' (end_of_word: {})",
-                padding, node.letter, node.end_of_word
+                padding, node.letter as char, node.end_of_word
             );
         }
         for child in node.children.iter().flatten() {
@@ -88,35 +93,34 @@ impl Trie {
 
     pub fn words_with_prefix(&self, prefix: &str) -> Vec<String> {
         let mut current = &self.root;
-        let mut results = Vec::new();
-        let mut prefix_accum = String::new();
+        let bytes = prefix.as_bytes();
 
-        for c in prefix.to_ascii_lowercase().chars() {
-            let idx = Node::char_to_index(c);
+        for &b in bytes {
+            let idx = Node::char_to_index(b);
             match &current.children[idx] {
-                Some(node) => {
-                    prefix_accum.push(c);
-                    current = node;
-                }
-                None => return results,
+                Some(node) => current = node,
+                None => return Vec::new(),
             }
         }
 
-        Self::collect_words_from_node(current, &mut prefix_accum, &mut results);
+        let mut results = Vec::new();
+        let mut buffer = prefix.to_ascii_lowercase().into_bytes();
+        self.collect_words_from_node(current, &mut buffer, &mut results);
         results
     }
 
     #[inline(always)]
-    fn collect_words_from_node(node: &Node, current_word: &mut String, results: &mut Vec<String>) {
+    fn collect_words_from_node(&self, node: &Node, buffer: &mut Vec<u8>, results: &mut Vec<String>) {
         if node.end_of_word {
-            results.push(current_word.clone());
+            results.push(String::from_utf8_lossy(buffer).into_owned());
         }
 
-        for child_opt in node.children.iter().flatten() {
-            let child = child_opt.as_ref();
-            current_word.push(child.letter);
-            Self::collect_words_from_node(child, current_word, results);
-            current_word.pop();
+        for (i, child_opt) in node.children.iter().enumerate() {
+            if let Some(child) = child_opt {
+                buffer.push(b'a' + i as u8);
+                self.collect_words_from_node(child, buffer, results);
+                buffer.pop();
+            }
         }
     }
 }

--- a/src/hypertrie/src/trie.rs
+++ b/src/hypertrie/src/trie.rs
@@ -27,12 +27,14 @@ pub struct Trie {
 
 impl Trie {
     pub fn new(size: usize, num_hashes: usize) -> Self {
+        let optimized_size = size.checked_next_power_of_two().expect("Next power of 2 usize overflow");
+
         let mut nodes = Vec::with_capacity(1024);
         nodes.push(Node::new(0));
 
         Trie {
             nodes,
-            bloom_filter: BloomFilter::new(size, num_hashes),
+            bloom_filter: BloomFilter::new(optimized_size, num_hashes),
         }
     }
 

--- a/src/hypertrie/src/trie.rs
+++ b/src/hypertrie/src/trie.rs
@@ -39,7 +39,7 @@ impl Trie {
     pub fn insert(&mut self, word: &str) {
         let mut current = &mut self.root;
 
-        for c in word.to_ascii_lowercase().chars() {
+        for c in word.chars().map(|c| c.to_ascii_lowercase()) {
             let idx = Node::char_to_index(c);
             if current.children[idx].is_none() {
                 current.children[idx] = Some(Box::new(Node::new(c)));


### PR DESCRIPTION
Reduce run time by 57.76%, making it about 136.75% faster than the previous implementation by flattening the Trie, using derived hashes, and optimizing the bulk insert.

Also take total allocations from about 2MB to ~85KB.