### PR TITLE
Enable stack allocated strings

### DIFF
--- a/src/HyperTrieCore.Tests/HyperTrieCore.Tests.csproj
+++ b/src/HyperTrieCore.Tests/HyperTrieCore.Tests.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
       <NoWarn>CS8604,NU1507</NoWarn>
+      <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HyperTrieCore.Tests/UTF8StringTests.cs
+++ b/src/HyperTrieCore.Tests/UTF8StringTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using Xunit;
+
+namespace HyperTrieCore.Tests
+{
+    public class Utf8StringTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Constructor_ShouldHandleNullOrEmpty(string? input)
+        {
+            // Act
+            using var utf8 = new Utf8String(input!);
+
+            // Assert
+            Assert.Equal(IntPtr.Zero, utf8.Pointer);
+        }
+
+        [Fact]
+        public void Constructor_ShouldHandleSmallString_StackPath()
+        {
+            // Arrange
+            string input = "Hello Stack";
+
+            // Act
+            using var utf8 = new Utf8String(input);
+
+            // Assert
+            Assert.NotEqual(IntPtr.Zero, utf8.Pointer);
+            string? result = Marshal.PtrToStringAnsi(utf8.Pointer); // Read back to verify
+            Assert.Equal(input, result);
+        }
+
+        [Fact]
+        public void Constructor_ShouldHandleLargeString_HeapPath()
+        {
+            // Arrange
+            // Create a string that exceeds the 256 byte threshold
+            // 300 characters will definitely exceed STACK_THRESHOLD
+            string input = new string('A', 300);
+
+            // Act
+            using var utf8 = new Utf8String(input);
+
+            // Assert
+            Assert.NotEqual(IntPtr.Zero, utf8.Pointer);
+
+            // Manual verification of the content at the pointer
+            byte[] buffer = new byte[input.Length];
+            Marshal.Copy(utf8.Pointer, buffer, 0, input.Length);
+            string result = Encoding.UTF8.GetString(buffer);
+
+            Assert.Equal(input, result);
+
+            // Verify null termination
+            byte nullTerminator = Marshal.ReadByte(utf8.Pointer, input.Length);
+            Assert.Equal(0, nullTerminator);
+        }
+
+        [Fact]
+        public void Dispose_ShouldResetPointer()
+        {
+            // Arrange
+            var utf8 = new Utf8String("Dispose Test");
+
+            // Act
+            utf8.Dispose();
+
+            // Assert
+            Assert.Equal(IntPtr.Zero, utf8.Pointer);
+        }
+
+        [Fact]
+        public unsafe void MemoryContents_ShouldBeValidUtf8()
+        {
+            // Arrange
+            string input = "🚀 High Perf"; // Includes a 4-byte emoji
+
+            // Act
+            using var utf8 = new Utf8String(input);
+
+            // Assert
+            byte* ptr = (byte*)utf8.Pointer;
+            int expectedByteCount = Encoding.UTF8.GetByteCount(input);
+
+            // Verify each byte matches Encoding.UTF8
+            byte[] expectedBytes = Encoding.UTF8.GetBytes(input);
+            for (int i = 0; i < expectedByteCount; i++)
+            {
+                Assert.Equal(expectedBytes[i], ptr[i]);
+            }
+
+            // Verify null terminator at the correct offset
+            Assert.Equal(0, ptr[expectedByteCount]);
+        }
+    }
+}

--- a/src/HyperTrieCore/AssemblyInfo.cs
+++ b/src/HyperTrieCore/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("HyperTrieCore.Tests")]

--- a/src/HyperTrieCore/TrieNative.cs
+++ b/src/HyperTrieCore/TrieNative.cs
@@ -47,10 +47,10 @@ public sealed class TrieNative(int size, int numHashes = 5) : IDisposable
     /// Inserts a new word into the TrieNative object.
     /// </summary>
     /// <param name="word">The word to insert.</param>
-    public void Insert(string word)
+    public unsafe void Insert(string word)
     {
         using var wordPtr = new Utf8String(word);
-        trie_insert(_handle, wordPtr.Pointer);
+        trie_insert(_handle, (nint)wordPtr.Pointer);
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public sealed class TrieNative(int size, int numHashes = 5) : IDisposable
         var result = new List<string>();
 
         using var prefixPtr = new Utf8String(prefix);
-        nint* wordsPtr = (IntPtr*)trie_words_with_prefix(_handle, prefixPtr.Pointer, out UIntPtr len);
+        nint* wordsPtr = (IntPtr*)trie_words_with_prefix(_handle, (nint)prefixPtr.Pointer, out UIntPtr len);
         uint count = len.ToUInt32();
 
         if (wordsPtr == null || count == 0)
@@ -105,10 +105,10 @@ public sealed class TrieNative(int size, int numHashes = 5) : IDisposable
     /// </summary>
     /// <param name="word">The word to search for.</param>
     /// <returns>A bool representing if the word is found or not.</returns>
-    public bool Contains(string word)
+    public unsafe bool Contains(string word)
     {
         using var testWord = new Utf8String(word);
-        return trie_contains(_handle, testWord.Pointer);
+        return trie_contains(_handle, (nint)testWord.Pointer);
     }
 
     /// <summary>

--- a/src/HyperTrieCore/TrieNative.cs
+++ b/src/HyperTrieCore/TrieNative.cs
@@ -50,7 +50,7 @@ public sealed class TrieNative(int size, int numHashes = 5) : IDisposable
     public unsafe void Insert(string word)
     {
         using var wordPtr = new Utf8String(word);
-        trie_insert(_handle, (nint)wordPtr.Pointer);
+        trie_insert(_handle, wordPtr.Pointer);
     }
 
     /// <summary>
@@ -63,7 +63,7 @@ public sealed class TrieNative(int size, int numHashes = 5) : IDisposable
         var result = new List<string>();
 
         using var prefixPtr = new Utf8String(prefix);
-        nint* wordsPtr = (IntPtr*)trie_words_with_prefix(_handle, (nint)prefixPtr.Pointer, out UIntPtr len);
+        nint* wordsPtr = (IntPtr*)trie_words_with_prefix(_handle, prefixPtr.Pointer, out UIntPtr len);
         uint count = len.ToUInt32();
 
         if (wordsPtr == null || count == 0)
@@ -108,7 +108,7 @@ public sealed class TrieNative(int size, int numHashes = 5) : IDisposable
     public unsafe bool Contains(string word)
     {
         using var testWord = new Utf8String(word);
-        return trie_contains(_handle, (nint)testWord.Pointer);
+        return trie_contains(_handle, testWord.Pointer);
     }
 
     /// <summary>

--- a/src/HyperTrieCore/Utf8String.cs
+++ b/src/HyperTrieCore/Utf8String.cs
@@ -9,6 +9,7 @@ namespace HyperTrieCore;
 internal unsafe ref struct Utf8String : IDisposable
 {
     private const int STACK_THRESHOLD = 256;
+    // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
     private fixed byte _fixedBuffer[STACK_THRESHOLD];
     private byte* _allocatedPtr;
     private bool _isHeapAllocated;

--- a/src/HyperTrieCore/Utf8String.cs
+++ b/src/HyperTrieCore/Utf8String.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace HyperTrieCore;
@@ -7,37 +8,57 @@ namespace HyperTrieCore;
 /// </summary>
 internal unsafe ref struct Utf8String : IDisposable
 {
-    private fixed byte _fixedBuffer[256];
-    public byte* Pointer { get; private set; }
-    public int Length { get; private set; }
+    private const int STACK_THRESHOLD = 256;
+    private fixed byte _fixedBuffer[STACK_THRESHOLD];
+    private byte* _allocatedPtr;
+    private bool _isHeapAllocated;
+    public IntPtr Pointer {get; private set;}
 
     public Utf8String(string str)
     {
+        _allocatedPtr = null;
+        _isHeapAllocated = false;
+
         if (string.IsNullOrEmpty(str))
         {
-            Pointer = null;
-            Length = 0;
+            Pointer = IntPtr.Zero;
             return;
         }
 
-        int byteCount = Encoding.UTF8.GetByteCount(str);
-
-        if (byteCount >= 256)
+        fixed (char* pStr = str)
         {
-            throw new ArgumentException($"{nameof(Utf8String)} is too long.");
-        }
+            int byteCount = Encoding.UTF8.GetByteCount(str);
+            int requiredSize = byteCount + 1; // +1 for null terminator
 
-        fixed (byte* pBuffer = _fixedBuffer)
-        {
-            fixed (char* pStr = str)
+            if (requiredSize <= STACK_THRESHOLD)
             {
-                Encoding.UTF8.GetBytes(pStr, str.Length, pBuffer, byteCount);
-                pBuffer[byteCount] = 0;
-                Pointer = pBuffer;
-                Length = byteCount;
+                fixed (byte* pBuffer = _fixedBuffer)
+                {
+                    Encoding.UTF8.GetBytes(pStr, str.Length, pBuffer, byteCount);
+                    pBuffer[byteCount] = 0;
+                    Pointer = (nint)pBuffer;
+                }
+            }
+            else
+            {
+                _allocatedPtr = (byte*)Marshal.AllocHGlobal(requiredSize);
+                _isHeapAllocated = true;
+                Encoding.UTF8.GetBytes(pStr, str.Length, _allocatedPtr, byteCount);
+                _allocatedPtr[byteCount] = 0;
+                Pointer = (nint)_allocatedPtr;
             }
         }
     }
 
-    public void Dispose() => Pointer = null;
+    public void Dispose()
+    {
+        if (_isHeapAllocated && _allocatedPtr != null)
+        {
+            Marshal.FreeHGlobal((IntPtr)_allocatedPtr);
+            _allocatedPtr = null;
+            _isHeapAllocated = false;
+        }
+
+        Pointer = IntPtr.Zero;
+    }
 }

--- a/src/HyperTrieCore/Utf8String.cs
+++ b/src/HyperTrieCore/Utf8String.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using System.Text;
 
 namespace HyperTrieCore;
@@ -8,44 +7,37 @@ namespace HyperTrieCore;
 /// </summary>
 internal unsafe ref struct Utf8String : IDisposable
 {
-    public IntPtr Pointer { get; private set; }
+    private fixed byte _fixedBuffer[256];
+    public byte* Pointer { get; private set; }
+    public int Length { get; private set; }
 
     public Utf8String(string str)
     {
         if (string.IsNullOrEmpty(str))
         {
-            Pointer = IntPtr.Zero;
+            Pointer = null;
+            Length = 0;
             return;
         }
 
-        fixed (char* pStr = str)
+        int byteCount = Encoding.UTF8.GetByteCount(str);
+
+        if (byteCount >= 256)
         {
-            int byteCount = Encoding.UTF8.GetByteCount(pStr, str.Length);
+            throw new ArgumentException($"{nameof(Utf8String)} is too long.");
+        }
 
-            Pointer = Marshal.AllocHGlobal(byteCount + 1);
-
-            byte* pDest = (byte*)Pointer;
-            Encoding.UTF8.GetBytes(pStr, str.Length, pDest, byteCount);
-
-            pDest[byteCount] = 0;
+        fixed (byte* pBuffer = _fixedBuffer)
+        {
+            fixed (char* pStr = str)
+            {
+                Encoding.UTF8.GetBytes(pStr, str.Length, pBuffer, byteCount);
+                pBuffer[byteCount] = 0;
+                Pointer = pBuffer;
+                Length = byteCount;
+            }
         }
     }
 
-    private bool _disposed = false;
-
-    public void Dispose()
-    {
-        if (_disposed)
-        {
-            return;
-        }
-
-        if (Pointer != IntPtr.Zero)
-        {
-            Marshal.FreeHGlobal(Pointer);
-            Pointer = IntPtr.Zero;
-        }
-
-        _disposed = true;
-    }
+    public void Dispose() => Pointer = null;
 }


### PR DESCRIPTION
Enables stack allocation with fixed arrays for small strings (< 256 bytes), else falls back on Heap via AllocHGlobal. I wanted to use InlineArrays and NativeMemory here but it is not available in .NET standard and PolySharp comes with its own downsides.