### PR TITLE
⚡ Bolt: optimize trie normalization and prefix collection

### DIFF
--- a/src/hypertrie/src/trie.rs
+++ b/src/hypertrie/src/trie.rs
@@ -59,14 +59,15 @@ impl Trie {
         let bytes = word.as_bytes();
         let len = bytes.len();
 
-        // Use stack buffer for normalization and filtering if word is short enough
+        // Optimization: Store direct bit indices (0..25) in the normalized buffer
+        // to eliminate offset addition (+ b'a') and subtraction (- b'a') in hot loops.
         let mut stack_buf = [0u8; 64];
         let mut filtered_len = 0;
         let normalized: Cow<[u8]> = if len <= 64 {
             for &b in bytes {
                 let bit_idx = unsafe { *CHAR_TO_BIT.get_unchecked(b as usize) };
                 if bit_idx != 255 {
-                    stack_buf[filtered_len] = b'a' + bit_idx;
+                    stack_buf[filtered_len] = bit_idx;
                     filtered_len += 1;
                 }
             }
@@ -76,21 +77,21 @@ impl Trie {
             for &b in bytes {
                 let bit_idx = unsafe { *CHAR_TO_BIT.get_unchecked(b as usize) };
                 if bit_idx != 255 {
-                    v.push(b'a' + bit_idx);
+                    v.push(bit_idx);
                 }
             }
             Cow::Owned(v)
         };
 
-        for &b in normalized.as_ref() {
-            let bit_idx = (b - b'a') as usize;
+        for &bit_byte in normalized.as_ref() {
+            let bit_idx = bit_byte as usize;
 
             // Check if child exists using bitmask
             unsafe {
                 let node = self.nodes.get_unchecked(current_idx);
                 if (node.children_mask & (1 << bit_idx)) == 0 {
                     let new_node_idx = self.nodes.len() as u32;
-                    self.nodes.push(Node::new(b));
+                    self.nodes.push(Node::new(bit_byte));
 
                     // Update parent
                     let node = self.nodes.get_unchecked_mut(current_idx);
@@ -114,14 +115,15 @@ impl Trie {
         let bytes = word.as_bytes();
         let len = bytes.len();
 
-        // Normalize once to a stack buffer
+        // Optimization: Store direct bit indices (0..25) in the normalized buffer
+        // to eliminate offset addition (+ b'a') and subtraction (- b'a') in hot loops.
         let mut stack_buf = [0u8; 64];
         let mut filtered_len = 0;
         let normalized: Cow<[u8]> = if len <= 64 {
             for &b in bytes {
                 let bit_idx = unsafe { *CHAR_TO_BIT.get_unchecked(b as usize) };
                 if bit_idx != 255 {
-                    stack_buf[filtered_len] = b'a' + bit_idx;
+                    stack_buf[filtered_len] = bit_idx;
                     filtered_len += 1;
                 }
             }
@@ -131,7 +133,7 @@ impl Trie {
             for &b in bytes {
                 let bit_idx = unsafe { *CHAR_TO_BIT.get_unchecked(b as usize) };
                 if bit_idx != 255 {
-                    v.push(b'a' + bit_idx);
+                    v.push(bit_idx);
                 }
             }
             Cow::Owned(v)
@@ -143,8 +145,8 @@ impl Trie {
         }
 
         let mut current_idx = 0;
-        for &b in normalized.as_ref() {
-            let bit_idx = (b - b'a') as usize;
+        for &bit_byte in normalized.as_ref() {
+            let bit_idx = bit_byte as usize;
 
             let node = unsafe { self.nodes.get_unchecked(current_idx) };
             if (node.children_mask & (1 << bit_idx)) == 0 {
@@ -170,7 +172,9 @@ impl Trie {
         } else {
             println!(
                 "{}'{}' (end_of_word: {})",
-                padding, node.letter as char, node.end_of_word
+                padding,
+                (b'a' + node.letter) as char,
+                node.end_of_word
             );
         }
 
@@ -231,17 +235,20 @@ impl Trie {
             }
         }
 
-        // Iterate through all possible children (a-z)
-        for i in 0..26 {
-            // Only recurse if the bitmask says a child exists
-            if (node.children_mask & (1 << i)) != 0 {
-                let child_idx = unsafe { *node.children_indices.get_unchecked(i) as usize };
+        // Optimization: Iterate only through active child branches using trailing_zeros on children_mask.
+        // This replaces a 26-slot loop with fast bit-twiddling (TZCNT instruction) to jump directly
+        // to set child bits, avoiding unnecessary loop iterations for sparse nodes.
+        let mut mask = node.children_mask;
+        while mask != 0 {
+            let i = mask.trailing_zeros() as usize;
+            mask &= mask - 1; // Clear lowest set bit
 
-                // Push the character for this branch
-                buffer.push(b'a' + i as u8);
-                self.collect_words_from_node(child_idx, buffer, results);
-                buffer.pop(); // Backtrack for the next branch
-            }
+            let child_idx = unsafe { *node.children_indices.get_unchecked(i) as usize };
+
+            // Push the character for this branch
+            buffer.push(b'a' + i as u8);
+            self.collect_words_from_node(child_idx, buffer, results);
+            buffer.pop(); // Backtrack for the next branch
         }
     }
 }

--- a/src/hypertrie/src/trie.rs
+++ b/src/hypertrie/src/trie.rs
@@ -300,4 +300,17 @@ mod tests {
         let unknowns = trie.words_with_prefix("unknown");
         assert!(unknowns.is_empty());
     }
+
+    #[test]
+    fn test_long_string_heap_normalization() {
+        let mut trie = Trie::new(100, 3);
+        let long_word = "a".repeat(100);
+        trie.insert(&long_word);
+        assert!(trie.contains(&long_word));
+
+        let long_word_with_invalid = "a!".repeat(50); // 100 chars, includes invalid '!' (bit_idx 255)
+        trie.insert(&long_word_with_invalid);
+        assert!(trie.contains(&long_word_with_invalid));
+        assert!(trie.contains(&"a".repeat(50))); // Normalized '!' stripped out
+    }
 }


### PR DESCRIPTION
Implemented performance optimizations in `src/hypertrie/src/trie.rs`:
1. Storing `bit_idx` directly in normalization buffers avoids `+ b'a'` addition during normalization and `- b'a'` subtraction during Trie node lookup in `insert` and `contains`.
2. Using `trailing_zeros` bit-twiddling (`TZCNT`) on `children_mask` in `collect_words_from_node` skips empty branches and iterates directly to active child nodes.

---
*PR created automatically by Jules for task [17268167718362437021](https://jules.google.com/task/17268167718362437021) started by @gregyjames*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved word and prefix lookup efficiency.
  * Reduced unnecessary processing during trie insertion and traversal.
  * Maintained readable letter output in debugging views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->